### PR TITLE
Option to cache signed S3 urls, in order to improve browser caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ Available settings
     # The expire time used to access S3 files.
     AWS_S3_MAX_AGE_SECONDS = 60*60
 
+    # Should cache the signed URL - aids in caching.
+    CACHE_AUTHENTICATED_URL = False
 
 How it works
 ------------

--- a/django_s3_storage/conf.py
+++ b/django_s3_storage/conf.py
@@ -63,5 +63,10 @@ class LazySettings(object):
         default = 60 * 60,  # 1 hours
     )
 
+    CACHE_AUTHENTICATED_URL = LazySetting(
+        name = "CACHE_AUTHENTICATED_URL",
+        default = False,
+    )
+
 
 settings = LazySettings(settings)


### PR DESCRIPTION
Caching of signed URL's - In order to improve caching on browser. I am writing unit test cases - However, I cannot run existing test cases - Is there a dependency or requirement that I am missing?
