### PR TITLE
Not to use force_bytes for cache-control header.

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -80,10 +80,10 @@ class S3Storage(Storage):
             privacy = "private"
         else:
             privacy = "public"
-        return force_bytes("{privacy}, max-age={max_age}".format(
+        return "{privacy},max-age={max_age}".format(
             privacy = privacy,
             max_age = self.aws_s3_max_age_seconds,
-        ))  # Have to use bytes else the space will be percent-encoded. Odd, eh?
+        )
 
     def _get_content_encoding(self, content_type):
         """


### PR DESCRIPTION
The `force_byets` cause a 403 Forbidden error:

```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>AK...</AWSAccessKeyId><StringToSign>AWS4-HMAC-SHA256
...
```

After tracking down, I found it was caused by `force_bytes`. 

Removing `force_bytes` causes another issue pointed out by your comment, ie the space will be percent-encoded. So I just remove the space at the same time. I know this is kind of tricky, but until now I haven't found a better way.
