### PR TITLE
Remove empty file name from the output of listdir().

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 django-s3-storage changelog
 ===========================
 
+0.9.12
+------
+
+- Bug fix for listdir() returning empty file names (@aaugustin).
+
+
 0.9.11
 ------
 

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -310,7 +310,8 @@ class S3Storage(Storage):
             key_path = key.name[len(path):]
             if key_path.endswith("/"):
                 dirs.add(key_path[:-1])
-            else:
+            # Remove the directory itself from the output of bucket.list().
+            elif key_path:
                 files.add(key_path)
         # All done!
         return list(dirs), list(files)


### PR DESCRIPTION
I noticed that the list of files in a directory other than the root contains the empty string.

It's unclear to me why S3 would include `"images/"` in the response to `bucket.list(prefix="images/")` but I'm seeing it.

Filtering it out can't harm as there's nothing you can do with an empty file name.