### PR TITLE
Manually add WOFF to mimetypes

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -224,6 +224,7 @@ class S3Storage(Storage):
             temp_file.seek(0)
             content = temp_file
         # Calculate the content type.
+        mimetypes.add_type('application/font-woff', '.woff')
         content_type, _ = mimetypes.guess_type(name, strict=False)
         content_type = content_type or "application/octet-stream"
         put_params["ContentType"] = content_type


### PR DESCRIPTION
Python's `mimetypes`  library incorrectly lists the WOFF content-type as `application/x-font-woff'; the correct type is `application/font-woff`.  As a result, AWS S3 does not properly handle the uploading of files of this type.  See https://en.wikipedia.org/wiki/Web_Open_Font_Format#Vendor_support

This PR enforces the proper content-type.  I've also filed a bug with Python itself, but if you find this manual override acceptable it will solve the problem directly irrespective of the `mimetypes` dependency.  

I'm not certain how to write a test for this given it is specific to what is returned by AWS, but I have verified it solves the problem.  