### PR TITLE
Add the missing Django 1.10 added api of get_modified_time

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -312,14 +312,16 @@ class S3Storage(Storage):
         # All done!
         return url
 
-    def accessed_time(self, name):
-        return self.modified_time(name)
-
-    def created_time(self, name):
-        return self.modified_time(name)
-
     def modified_time(self, name):
         return make_naive(self.meta(name)["LastModified"], utc)
+
+    created_time = accessed_time = modified_time
+
+    def get_modified_time(self, name):
+        timestamp = self.meta(name)["LastModified"]
+        return timestamp if settings.USE_TZ else make_naive(timestamp)
+
+    get_created_time = get_accessed_time = get_modified_time
 
     def sync_meta_iter(self):
         paginator = self.s3_connection.get_paginator("list_objects_v2")

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     django110: Django>=1.10,<1.11
     coverage>=4.1
     requests
+    pytz
 commands =
     coverage-erase: coverage erase
     test: coverage run tests/manage.py test tests


### PR DESCRIPTION
Hello competitor!

I noticed you were missing the Django 1.10 ``get_modified_time`` api when I was looking through your storage implementation. ``collectstatic`` is expecting that api on 1.10+.

Question: Why always pass in `utc` to `make_naive`? If you don't pass in a timezone it will use whatever the user has set.