### PR TITLE
Pass bytes to put_object on save instead of original fo

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -84,6 +84,7 @@ class S3Storage(Storage):
         "AWS_S3_METADATA": {},
         "AWS_S3_ENCRYPT_KEY": False,
         "AWS_S3_GZIP": True,
+        "AWS_S3_SIGNATURE_VERSION": None,
     }
 
     s3_settings_suffix = ""
@@ -124,6 +125,7 @@ class S3Storage(Storage):
             connection_kwargs["endpoint_url"] = self.settings.AWS_S3_ENDPOINT_URL
         self.s3_connection = boto3.client("s3", config=Config(
             s3={"addressing_style": self.settings.AWS_S3_ADDRESSING_STYLE},
+            signature_version=self.settings.AWS_S3_SIGNATURE_VERSION,
         ), **connection_kwargs)
 
     def _setting_changed_received(self, setting, **kwargs):
@@ -246,7 +248,7 @@ class S3Storage(Storage):
                 else:
                     content.seek(0)
         # Save the file.
-        self.s3_connection.put_object(Body=content, **put_params)
+        self.s3_connection.put_object(Body=content.read(), **put_params)
         # Close all temp files.
         for temp_file in temp_files:
             temp_file.close()


### PR DESCRIPTION
I was using it with `django-imagekit`. When I tried to access the `ImageSpecField` field,  I was getting such a stacktrace:

```python
OSError                                   Traceback (most recent call last)
<ipython-input-45-7ce50cad28f7> in <module>()
----> 1 f = photo.thumbnail._generate()

/usr/local/lib/python3.6/site-packages/imagekit/cachefiles/__init__.py in _generate(self)
     97         content = generate(self.generator)
     98
---> 99         actual_name = self.storage.save(self.name, content)
    100
    101         # We're going to reuse the generated file, so we need to reset the pointer.

/usr/local/lib/python3.6/site-packages/django/core/files/storage.py in save(self, name, content, max_length)
     52
     53         name = self.get_available_name(name, max_length=max_length)
---> 54         return self._save(name, content)
     55
     56     # These methods are part of the public API, with default implementations.

/usr/local/lib/python3.6/site-packages/django_s3_storage/storage.py in _do_wrap_errors(self, name, *args, **kwargs)
     30             return func(self, name, *args, **kwargs)
     31         except ClientError as ex:
---> 32             raise OSError("S3Storage error at {!r}: {}".format(name, force_text(ex)))
     33     return _do_wrap_errors
     34

OSError: S3Storage error at 'CACHE/images/albums/photos/200px-Spooky_AXHqF06/b54ae1fe76bb80a0fd4796b40d5e1625.png': An error occurred (XAmzContentSHA256Mismatch) when calling the PutObject operation: The provided 'x-amz-content-sha256' header does not match what was computed.
```

So basically after some debugging the exception was reproducible by:
```python
from imagekit.cachefiles import generate

f = generate(photo.thumbnail.generator)
photo.thumbnail.storage._save("f", f)
...
ClientError: An error occurred (XAmzContentSHA256Mismatch) when calling the PutObject operation: The provided 'x-amz-content-sha256' header does not match what was computed.
```

Not entirely sure what is going one behind the scenes, maybe `f` is read twice inside `boto`, which produces different results thus the sha does not match.

So I added an explicit `read` call before passing the file to the `put_object` call and it worked.
Also while playing with that I added `AWS_S3_SIGNATURE_VERSION` setting as I thought it causes the problem. Can remove it if you think there is no point in having it.