### PR TITLE
Allow configuring the signature version used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 django-s3-storage changelog
 ===========================
 
+In development
+--------------
+
+- Added `AWS_S3_SIGNATURE_VERSION` setting.
+- *Breaking* Changed the default signature version for S3 to v4.
+  According to the `AWS documentation <http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region>` all S3 regions support v4 (but not all support v2).
+
 0.11.2
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,9 @@ Use the following settings to configure the S3 file storage. You must provide at
     # Important: Changing this setting will not affect existing files.
     AWS_S3_GZIP = True
 
+    # Set to 's3v4' to use the current signature for S3 requests
+    AWS_S3_SIGNATURE_VERSION = None
+
 
 **Important:** Several of these settings (noted above) will not affect existing files. To sync the new settings to
 existing files, run ``./manage.py s3_sync_meta django.core.files.storage.default_storage``.

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -84,6 +84,7 @@ class S3Storage(Storage):
         "AWS_S3_METADATA": {},
         "AWS_S3_ENCRYPT_KEY": False,
         "AWS_S3_GZIP": True,
+        "AWS_S3_SIGNATURE_VERSION": None,
     }
 
     s3_settings_suffix = ""
@@ -124,6 +125,7 @@ class S3Storage(Storage):
             connection_kwargs["endpoint_url"] = self.settings.AWS_S3_ENDPOINT_URL
         self.s3_connection = boto3.client("s3", config=Config(
             s3={"addressing_style": self.settings.AWS_S3_ADDRESSING_STYLE},
+            signature_version=self.settings.AWS_S3_SIGNATURE_VERSION,
         ), **connection_kwargs)
 
     def _setting_changed_received(self, setting, **kwargs):

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -84,7 +84,7 @@ class S3Storage(Storage):
         "AWS_S3_METADATA": {},
         "AWS_S3_ENCRYPT_KEY": False,
         "AWS_S3_GZIP": True,
-        "AWS_S3_SIGNATURE_VERSION": None,
+        "AWS_S3_SIGNATURE_VERSION": "s3v4",
     }
 
     s3_settings_suffix = ""


### PR DESCRIPTION
The s3-central-1 region (Frankfurt) only supports SigV4. I just lost an hour again (my own failure writing down solutions is the cause) determining what I should do to fix S3 access.

I have a feeling that this wasn't necessary in a project I started one month ago, but that's quite impossible since both use the Frankfurt region for S3, but I can't for the life of me determine what I did do differently then.

Thanks!

Addendum: According to http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region it should also be possible to NOT make this configurable at all but simply set the value to `s3v4`, since SigV4 seems to be supported everywhere. 