### PR TITLE
Added django-storages's AWS_S3_FILE_OVERWRITE functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,9 @@ Use the following settings to configure the S3 file storage. You must provide at
     # The signature version to use for S3 requests.
     AWS_S3_SIGNATURE_VERSION = None
 
+    # If True, then files with the same name will overwrite each other. By default it's set to False to have
+    # extra characters appended.
+    AWS_S3_FILE_OVERWRITE =  False
 
 **Important:** Several of these settings (noted above) will not affect existing files. To sync the new settings to
 existing files, run ``./manage.py s3_sync_meta django.core.files.storage.default_storage``.

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -361,13 +361,10 @@ class S3Storage(Storage):
                 yield name
 
     def get_available_name(self, name, max_length=None):
+        name = self._get_key_name(name)
         if self.settings.AWS_S3_FILE_OVERWRITE:
-            name = self._clean_name(name)
             return name
         return super(S3Storage, self).get_available_name(name, max_length)
-
-    def _clean_name(self, name):
-        return os.path.normpath(name).replace('\\', '/')
 
     def sync_meta(self):
         for path in self.sync_meta_iter():

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -85,6 +85,7 @@ class S3Storage(Storage):
         "AWS_S3_ENCRYPT_KEY": False,
         "AWS_S3_GZIP": True,
         "AWS_S3_SIGNATURE_VERSION": "s3v4",
+        "AWS_S3_FILE_OVERWRITE": False
     }
 
     s3_settings_suffix = ""
@@ -358,6 +359,15 @@ class S3Storage(Storage):
                     **put_params
                 )
                 yield name
+
+    def get_available_name(self, name, max_length=None):
+        if self.settings.AWS_S3_FILE_OVERWRITE:
+            name = self._clean_name(name)
+            return name
+        return super(S3Storage, self).get_available_name(name, max_length)
+
+    def _clean_name(self, name):
+        return os.path.normpath(name).replace('\\', '/')
 
     def sync_meta(self):
         for path in self.sync_meta_iter():


### PR DESCRIPTION
Hello @etianen 

I encountered within one of my projects problem when with for example coffee script with .js and .map files JS file was not overridden but with functionality of Storage.get_available_name() new filename is generated. 

With this when using backend as static storage, some files are not copied to S3 and on each run new files are created. This functionality is OK for default storage but a problem for static storage.

Created fix, code is taken from django-storage, more info founded here: https://github.com/jschneier/django-storages/issues/291

Please review the code and if pulled, I can switch back to your upstream version :-)

