### PR TITLE
Add admin static assets note to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Staticfiles storage settings
 ----------------------------
 
 All of the file storage settings are available for the staticfiles storage, suffixed with ``_STATIC``.
-You must provide at least ``AWS_S3_BUCKET_NAME_STATIC``.
+You must provide at least ``AWS_S3_BUCKET_NAME_STATIC``. The django admin assets are served from the static storage backend. The admin app will be missing css/js/images until you run ``collectstatic``. If you receive the error ``Invalid bucket name`` while running ``collectstatic``, be sure ``AWS_S3_BUCKET_NAME_STATIC`` is set.
 
 The following staticfiles storage settings have different default values to their file storage counterparts.
 


### PR DESCRIPTION
After struggling to get the django admin static assets (css/js/images) to load, I was eventually led to this comment on an old issue. https://github.com/etianen/django-s3-storage/issues/53#issuecomment-309372639

It looks like others have also had this hurdle and also found that comment helpful.

This PR adds a note to the README to make this part of the settings clearer.