### PR TITLE
Add support for AWS KMS encryption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,9 +95,15 @@ Use the following settings to configure the S3 file storage. You must provide at
     # Important: Changing this setting will not affect existing files.
     AWS_S3_METADATA = {}
 
-    # If True, then files will be stored using server-side encryption.
+    # If True, then files will be stored using AES256 server-side encryption.
+    # If this is a string value (e.g., "aws:kms"), that encryption type will be used.
+    # Otherwise, server-side encryption is not be enabled.
     # Important: Changing this setting will not affect existing files.
     AWS_S3_ENCRYPT_KEY = False
+
+    # The AWS S3 KMS encryption key ID (the `SSEKMSKeyId` parameter) is set from this string if present.
+    # This is only relevant if AWS S3 KMS server-side encryption is enabled (above).
+    AWS_S3_KMS_ENCRYPTION_KEY_ID = ""
 
     # If True, then text files will be stored using gzip content encoding. Files will only be gzipped if their
     # compressed size is smaller than their uncompressed size.

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -141,6 +141,7 @@ class S3Storage(Storage):
         "AWS_S3_CONTENT_LANGUAGE": "",
         "AWS_S3_METADATA": {},
         "AWS_S3_ENCRYPT_KEY": False,
+        "AWS_S3_KMS_ENCRYPTION_KEY_ID": "",
         "AWS_S3_GZIP": True,
         "AWS_S3_SIGNATURE_VERSION": "s3v4",
         "AWS_S3_FILE_OVERWRITE": False
@@ -238,8 +239,13 @@ class S3Storage(Storage):
         if content_langauge:
             params["ContentLanguage"] = content_langauge
         # Set server-side encryption.
-        if self.settings.AWS_S3_ENCRYPT_KEY:
-            params["ServerSideEncryption"] = "AES256"
+        if self.settings.AWS_S3_ENCRYPT_KEY:  # If this if False / None / empty then no encryption
+            if isinstance(self.settings.AWS_S3_ENCRYPT_KEY, str):
+                params["ServerSideEncryption"] = self.settings.AWS_S3_ENCRYPT_KEY
+                if self.settings.AWS_S3_KMS_ENCRYPTION_KEY_ID:
+                    params["SSEKMSKeyId"] = self.settings.AWS_S3_KMS_ENCRYPTION_KEY_ID
+            else:
+                params["ServerSideEncryption"] = "AES256"
         # All done!
         return params
 


### PR DESCRIPTION
Supports AWS KMS for Server Side Encryption
Param "SSEKMSKeyId" is set from the AWS_S3_KMS_ENCRYPTION_KEY_ID setting

Fixes issue #72