### PR TITLE
Accept case insensitive in storage initialization.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,8 +135,6 @@ These settings can be provided in field storage definition like this:
         name = models.CharField(max_length=255)
         photo = models.ImageField(storage=storage)
 
-**Note:** settings key in storage definition should be `lowercase`.
-
 Staticfiles storage settings
 ----------------------------
 

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -157,7 +157,7 @@ class S3Storage(Storage):
                 self.settings,
                 setting_key,
                 self._kwargs.get(
-                    setting_key.lower(),
+                    setting_key,
                     getattr(settings, setting_key, setting_default_value),
                 ),
             )
@@ -166,7 +166,7 @@ class S3Storage(Storage):
                 self.settings,
                 setting_key,
                 self._kwargs.get(
-                    setting_key.lower(),
+                    setting_key,
                     getattr(settings, setting_key + self.s3_settings_suffix, setting_default_value),
                 ),
             )
@@ -186,12 +186,14 @@ class S3Storage(Storage):
 
     def __init__(self, **kwargs):
         # Check for unknown kwargs.
-        for kwarg_key in kwargs.keys():
+        for kwarg_key, kwarg_value in kwargs.items():
+            kwarg_key = kwarg_key.upper()
             if (
-                kwarg_key.upper() not in self.default_auth_settings and
-                kwarg_key.upper() not in self.default_s3_settings
+                kwarg_key not in self.default_auth_settings and
+                kwarg_key not in self.default_s3_settings
             ):
                 raise ImproperlyConfigured("Unknown S3Storage parameter: {}".format(kwarg_key))
+            kwargs[kwarg_key] = kwarg_value
         # Set up the storage.
         self._kwargs = kwargs
         self._setup()

--- a/tests/django_s3_storage_test/tests.py
+++ b/tests/django_s3_storage_test/tests.py
@@ -46,6 +46,7 @@ class TestS3Storage(SimpleTestCase):
     def testSettingsOverwrittenByKwargs(self):
         self.assertEqual(S3Storage().settings.AWS_S3_CONTENT_LANGUAGE, "")
         self.assertEqual(S3Storage(aws_s3_content_language="foo").settings.AWS_S3_CONTENT_LANGUAGE, "foo")
+        self.assertEqual(S3Storage(AWS_S3_CONTENT_LANGUAGE="foo").settings.AWS_S3_CONTENT_LANGUAGE, "foo")
 
     def testSettingsCannotUsePublicUrlAndBucketAuth(self):
         self.assertRaises(ImproperlyConfigured, lambda: S3Storage(


### PR DESCRIPTION
With this change we can pass case insensitive param in storage initialization.

Now, we should use params lowercase like this:
`storage = S3Storage(aws_s3_bucket_name='test_bucket')`

Users usually copy the settings keys from readme and all keys in readme are upper case. so this may make users mistakes. 