### PR TITLE
Allow generating URLs with extra parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,30 @@ To make media files public, and enable aggressive caching, make the following ch
 The default settings for staticfiles storage are already optimizing for aggressive caching.
 
 
+Custom URLs
+-----------
+
+Sometimes the default settings aren't flexible enough and custom handling of object is needed. For
+example, the ``Content-Disposition`` might be set to force download of a file instead of opening
+it:
+
+.. code:: python
+
+    url = storage.url("foo/bar.pdf", extra_params={"ResponseContentDisposition": "attachment"})
+
+Another example is a link to a specific version of the file (within a bucket that has versioning
+enabled):
+
+.. code:: python
+
+    url = storage.url("foo/bar.pdf", extra_params={"VersionId": "FRy3fTduRtqHsRAoNp0REzPJj_WunDfl"})
+
+The ``extra_params`` dict accepts the same parameters as `get_object() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object>`_.
+
+Please note, however, that **custom URLs will not work with AWS_S3_PUBLIC_URL** where the
+URL doesn't accept extra parameters, and it will raise ``ValueError``.
+
+
 Management commands
 -------------------
 

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -399,6 +399,9 @@ class S3Storage(Storage):
     def url(self, name, extra_params=None):
         # Use a public URL, if specified.
         if self.settings.AWS_S3_PUBLIC_URL:
+            if extra_params:
+                raise ValueError("Use of extra_params to generate custom URLs is not allowed "
+                        "with AWS_S3_PUBLIC_URL")
             return urljoin(self.settings.AWS_S3_PUBLIC_URL, filepath_to_uri(name))
         # Otherwise, generate the URL.
         params = extra_params.copy() if extra_params else {}

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -389,14 +389,16 @@ class S3Storage(Storage):
     def size(self, name):
         return self.meta(name)["ContentLength"]
 
-    def url(self, name):
+    def url(self, name, extra_params=None):
         # Use a public URL, if specified.
         if self.settings.AWS_S3_PUBLIC_URL:
             return urljoin(self.settings.AWS_S3_PUBLIC_URL, filepath_to_uri(name))
         # Otherwise, generate the URL.
+        params = extra_params.copy() if extra_params else {}
+        params.update(self._object_params(name))
         url = self.s3_connection.generate_presigned_url(
             ClientMethod="get_object",
-            Params=self._object_params(name),
+            Params=params,
             ExpiresIn=self.settings.AWS_S3_MAX_AGE_SECONDS,
         )
         # Strip off the query params if we're not interested in bucket auth.

--- a/tests/django_s3_storage_test/tests.py
+++ b/tests/django_s3_storage_test/tests.py
@@ -107,6 +107,48 @@ class TestS3Storage(SimpleTestCase):
             response_unauthenticated = requests.get(url_unauthenticated)
             self.assertEqual(response_unauthenticated.status_code, 403)
 
+    def testCustomUrlContentDisposition(self):
+        name = "foo/bar.txt"
+        with self.save_file(name=name, content="foo" * 4096):
+            url = default_storage.url(name, extra_params={"ResponseContentDisposition": "attachment"})
+            self.assertIn("response-content-disposition=attachment", url)
+            rsp = requests.get(url)
+            self.assertEqual(rsp.status_code, 200)
+            self.assertIn("Content-Disposition", rsp.headers)
+            self.assertEqual(rsp.headers["Content-Disposition"], "attachment")
+
+    def testCustomUrlWhenPublicURL(self):
+        with self.settings(AWS_S3_PUBLIC_URL="/foo/", AWS_S3_BUCKET_AUTH=False):
+            name = "bar.txt"
+            with self.save_file(name=name, content="foo" * 4096):
+                self.assertRaises(
+                    ValueError,
+                    default_storage.url,
+                    name,
+                    extra_params={"ResponseContentDisposition": "attachment"})
+
+    def testCustomUrlVersionId(self):
+        with self.settings(AWS_S3_FILE_OVERWRITE=True):
+            name = "foo/bar.txt"
+            content1 = "foo" * 512
+            with self.save_file(name=name, content=content1):
+                meta = default_storage.meta(name)
+                self.assertIn("VersionId", meta,
+                    u"VersionId not found in object meta. Make sure the bucket supports versioning.")
+                version1_id = meta["VersionId"]
+                content2 = "bar" * 1024
+                with self.save_file(name=name, content=content2):
+                    meta = default_storage.meta(name)
+                    version2_id = meta["VersionId"]
+                    url1 = default_storage.url(name, extra_params={"VersionId": version1_id})
+                    rsp = requests.get(url1)
+                    self.assertEqual(rsp.status_code, 200)
+                    self.assertEqual(rsp.content, content1)
+                    url2 = default_storage.url(name, extra_params={"VersionId": version2_id})
+                    rsp = requests.get(url2)
+                    self.assertEqual(rsp.status_code, 200)
+                    self.assertEqual(rsp.content, content2)
+
     def testExists(self):
         self.assertFalse(default_storage.exists("foo.txt"))
         with self.save_file():


### PR DESCRIPTION
This simple extension allows generating signed URLs with custom parameters, e.g. changing content disposition or cache control for individual links.