### PR TITLE
Allow Content-Disposition header to be set for presigned URL response

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -389,6 +389,13 @@ class S3Storage(Storage):
     def size(self, name):
         return self.meta(name)["ContentLength"]
 
+    def _presigned_url_params(self, name):
+        params = self._object_params(name)
+        content_disposition = _callable_setting(self.settings.AWS_S3_CONTENT_DISPOSITION, name)
+        if content_disposition:
+            params.update({ "ResponseContentDisposition", content_disposition })
+        return params
+
     def url(self, name):
         # Use a public URL, if specified.
         if self.settings.AWS_S3_PUBLIC_URL:
@@ -396,7 +403,7 @@ class S3Storage(Storage):
         # Otherwise, generate the URL.
         url = self.s3_connection.generate_presigned_url(
             ClientMethod="get_object",
-            Params=self._object_params(name),
+            Params=self._presigned_url_params(name),
             ExpiresIn=self.settings.AWS_S3_MAX_AGE_SECONDS,
         )
         # Strip off the query params if we're not interested in bucket auth.


### PR DESCRIPTION
The use case I have, is that I want to present the user with a custom/human-readable file name when redirecting to a file download on S3 using a presigned URL—without having to rename the object on the bucket.

This involves requesting the S3 API to return a `Content-Disposition: filename=my-readable-file.ext`. The boto library allows this value to be passed with the [`Params`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.generate_presigned_url) when generating the presigned URL. 

I didn't know what was the best way to pass this value from the model to the storage provider, but since there was already a setting for it, I decided to repurpose that one. 