### PR TITLE
Adapt sync_meta() to keep uncompressed size info; add tests

### DIFF
--- a/tests/django_s3_storage_test/settings.py
+++ b/tests/django_s3_storage_test/settings.py
@@ -16,6 +16,8 @@ AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
 AWS_S3_BUCKET_NAME = os.environ.get("AWS_S3_BUCKET_NAME")
 
 AWS_S3_KEY_PREFIX = uuid.uuid4().hex


### PR DESCRIPTION
This PR fixes `sync_meta()` to preserve info about uncompressed size, and adds tests to cover those changes.