### PR TITLE
Add support for Django 2.2 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
   fast_finish: true
   include:
     - { python: "2.7", env: DJANGO="~=1.11.0" }
+    - { python: "3.8", env: DJANGO="~=2.2.8" }
 install:
  - pip install flake8 coverage django$DJANGO requests pytz -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: xenial
 sudo: false
 language: python
 python:
+  - 3.7
   - 3.6
   - 3.5
 cache: pip
@@ -16,15 +18,13 @@ env:
     # AWS_S3_BUCKET_NAME
     - secure: "J9RE3MbU26kmTg5y8WwMD0RnW99SxjJvNY4uFfdbDuPlAn6BV9BQuq1qaPYGksdYdJ8WmXhlRKIhjXjZIgvIEzDQ0msPbJ3dU7uCJFrZRVG3I/jbZR0EfcOiWCaDuQU2TDZw5bo4qanTr4nnZpnBVqj0erjytxUkyqIuRAR3xOg="
   matrix:
-    - DJANGO='>=2.0,<2.1'
-    - DJANGO='>=2.1,<2.2'
+    - DJANGO='~=2.0.0'
+    - DJANGO='~=2.1.0'
+    - DJANGO='~=2.2.0'
 matrix:
   fast_finish: true
   include:
-    - { python: "2.7", env: DJANGO="==1.11.*" }
-
-    - { python: "3.7", env: DJANGO="==2.0.*", dist: xenial, sudo: true }
-    - { python: "3.7", env: DJANGO="==2.1.*", dist: xenial, sudo: true }
+    - { python: "2.7", env: DJANGO="~=1.11.0" }
 install:
  - pip install flake8 coverage django$DJANGO requests pytz -e .
 script:
@@ -39,7 +39,7 @@ deploy:
     secure: T6owRJudXfLP2cntqbsyAMHnOq6rbIAgXfEt1a9smDjyxyXpCH+XAxUWw+5mMZ3mFALyquZGzodtq+cil2j7XkB5gW0fQfo8YtoqjrrIdgvmWLS2zur9c1U+DXIG8vjLLkMiKTg1TXoeb0phELIme4Clxb9KuSKTaFosKWdVy8g=
   on:
     tags: true
-    condition: $DJANGO = '>=2.0,<2.1'
+    condition: $DJANGO = '~=2.2.0'
     python: 3.6
     repo: etianen/django-s3-storage
   distributions: sdist

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Framework :: Django",
     ],
 )


### PR DESCRIPTION
@etianen Can you create a release with this?  Then there's one release with support for the two django LTS releases 1.11 and 2.2.

Afterwards I'd like to remove support for Django < 2.2 (2.1's [EOL is in December](https://www.djangoproject.com/download/)) and add support for Django 3.0 (beta 1 already available; [release schedule](https://code.djangoproject.com/wiki/Version3.0Roadmap#schedule)).