### PR TITLE
Drop support for Django < 2.2 (incl. Python < 3.5); add Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
   fast_finish: true
   include:
     - { python: "2.7", env: DJANGO="~=1.11.0" }
-    - { python: "3.8", env: DJANGO="~=2.2.8" }
+    - { python: "3.8", env: DJANGO="~=2.2.7" }
 install:
  - pip install flake8 coverage django$DJANGO requests pytz -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.8
   - 3.7
   - 3.6
-  - 3.5
 cache: pip
 env:
   global:
@@ -20,8 +19,11 @@ env:
     - secure: "J9RE3MbU26kmTg5y8WwMD0RnW99SxjJvNY4uFfdbDuPlAn6BV9BQuq1qaPYGksdYdJ8WmXhlRKIhjXjZIgvIEzDQ0msPbJ3dU7uCJFrZRVG3I/jbZR0EfcOiWCaDuQU2TDZw5bo4qanTr4nnZpnBVqj0erjytxUkyqIuRAR3xOg="
   matrix:
     - DJANGO='~=2.2.7'
+    - DJANGO='>=3.0b1,<3.1'
 matrix:
   fast_finish: true
+  include:
+    - { python: "3.5", env: DJANGO="~=2.2" }
 install:
  - pip install flake8 coverage django$DJANGO requests pytz -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 sudo: false
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
   - 3.5
@@ -18,14 +19,9 @@ env:
     # AWS_S3_BUCKET_NAME
     - secure: "J9RE3MbU26kmTg5y8WwMD0RnW99SxjJvNY4uFfdbDuPlAn6BV9BQuq1qaPYGksdYdJ8WmXhlRKIhjXjZIgvIEzDQ0msPbJ3dU7uCJFrZRVG3I/jbZR0EfcOiWCaDuQU2TDZw5bo4qanTr4nnZpnBVqj0erjytxUkyqIuRAR3xOg="
   matrix:
-    - DJANGO='~=2.0.0'
-    - DJANGO='~=2.1.0'
-    - DJANGO='~=2.2.0'
+    - DJANGO='~=2.2.7'
 matrix:
   fast_finish: true
-  include:
-    - { python: "2.7", env: DJANGO="~=1.11.0" }
-    - { python: "3.8", env: DJANGO="~=2.2.7" }
 install:
  - pip install flake8 coverage django$DJANGO requests pytz -e .
 script:

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -10,6 +10,7 @@ from functools import wraps
 from io import TextIOBase
 from tempfile import SpooledTemporaryFile
 from threading import local
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import boto3
 from botocore.client import Config
@@ -22,7 +23,6 @@ from django.core.files.storage import Storage
 from django.core.signals import setting_changed
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import filepath_to_uri, force_bytes, force_str, force_text
-from django.utils.six.moves.urllib.parse import urljoin, urlsplit, urlunsplit
 from django.utils.timezone import make_naive, utc
 
 # Some parts of Django expect an IOError, other parts expect an OSError, so this class inherits both!

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/etianen/django-s3-storage",
     packages=find_packages(),
     install_requires=[
-        "django>=1.11",
+        "django>=2.2",
         "boto3>=1.4.4,<2",
     ],
     classifiers=[
@@ -26,7 +26,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/django_s3_storage_test/tests.py
+++ b/tests/django_s3_storage_test/tests.py
@@ -1,20 +1,23 @@
 # coding=utf-8
 from __future__ import unicode_literals
+
+import posixpath
+import time
 from contextlib import contextmanager
 from datetime import timedelta
-import posixpath
+from io import StringIO
+from urllib.parse import urlsplit, urlunsplit
+
 import requests
-import time
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from django.core.management import call_command, CommandError
-from django.contrib.staticfiles.storage import staticfiles_storage
+from django.core.management import CommandError, call_command
 from django.test import SimpleTestCase
-from django.utils.six import StringIO, assertRegex
-from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
 from django.utils import timezone
 from django.utils.timezone import is_naive, make_naive, utc
+
 from django_s3_storage.storage import S3Error, S3Storage, StaticS3Storage
 
 
@@ -354,7 +357,7 @@ class TestS3Storage(SimpleTestCase):
             # The URL should not contain query string authentication.
             self.assertFalse(urlsplit(url).query)
             # The URL should contain an MD5 hash.
-            assertRegex(self, url, r"foo\.[0-9a-f]{12}\.css$")
+            self.assertRegex(url, r"foo\.[0-9a-f]{12}\.css$")
             # The hashed name should be accessible and have a huge cache control.
             response = requests.get(url)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Not sure if tests will pass when running against Django 3.0.  Travis runs only on branch `master`.

Followup of etianen/django-s3-storage#101