### PR TITLE
Fixed issue #110: Removed validation for certain settings

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -179,15 +179,6 @@ class S3Storage(Storage):
         # Validate settings.
         if not self.settings.AWS_S3_BUCKET_NAME:
             raise ImproperlyConfigured(f"Setting AWS_S3_BUCKET_NAME{self.s3_settings_suffix} is required.")
-        if not (
-            (self.settings.AWS_ACCESS_KEY_ID and self.settings.AWS_SECRET_ACCESS_KEY) or
-            self.settings.AWS_SESSION_TOKEN
-        ):
-            raise ImproperlyConfigured(
-                f"Settings AWS_ACCESS_KEY_ID{self.s3_settings_suffix} "
-                f"and AWS_SECRET_ACCESS_KEY{self.s3_settings_suffix}, or "
-                f"AWS_SESSION_TOKEN{self.s3_settings_suffix}, is required."
-            )
         if self.settings.AWS_S3_PUBLIC_URL and self.settings.AWS_S3_BUCKET_AUTH:
             raise ImproperlyConfigured(
                 f"Cannot use AWS_S3_BUCKET_AUTH{self.s3_settings_suffix} "


### PR DESCRIPTION
We can't validate the presence of the settings below because these can
be detected by boto by using the AWS instance metadata service.

AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN

Technical discussion in issue 110:
https://github.com/etianen/django-s3-storage/issues/110