### PR TITLE
Django 4.0: replace deprecated `force_text` with `force_str`

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -23,7 +23,7 @@ from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.core.signals import setting_changed
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import filepath_to_uri, force_bytes, force_str, force_text
+from django.utils.encoding import filepath_to_uri, force_bytes, force_str
 from django.utils.timezone import make_naive, utc
 
 log = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ def _wrap_errors(func):
             err_cls = OSError
             if code == "NoSuchKey":
                 err_cls = FileNotFoundError
-            raise err_cls("S3Storage error at {!r}: {}".format(name, force_text(ex)))
+            raise err_cls("S3Storage error at {!r}: {}".format(name, force_str(ex)))
     return _do_wrap_errors
 
 


### PR DESCRIPTION
I was just trying out the [Django 4.0 alpha 1](https://www.djangoproject.com/weblog/2021/sep/21/django-40-alpha-1-released/) in a project and `force_text` has been removed in [Django 4.0](https://docs.djangoproject.com/en/dev/releases/4.0/#features-removed-in-4-0) (was deprecated in [3.0](https://docs.djangoproject.com/en/dev/releases/3.0/#django-utils-encoding-force-text-and-smart-text)).

In Django 3.2 it was [just an alias](https://github.com/django/django/blob/stable/3.2.x/django/utils/encoding.py#L110-L115) to `force_str` and in older Django's like 1.11 (which still needed to support Python2) it was [doing a bit more](https://github.com/django/django/blob/stable/1.11.x/django/utils/encoding.py#L58-L97).