### PR TITLE
switching to upload_fileobj

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -325,7 +325,8 @@ class S3Storage(Storage):
                 else:
                     content.seek(0)
         # Save the file.
-        self.s3_connection.put_object(Body=content.read(), **put_params)
+        self.s3_connection.upload_fileobj(content, put_params.pop('Bucket'), put_params.pop('Key'),
+                                          ExtraArgs=put_params)
         # Close all temp files.
         for temp_file in temp_files:
             temp_file.close()


### PR DESCRIPTION
## Why is the change needed?
see https://github.com/etianen/django-s3-storage/issues/133

## Documentation
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html

## Testing
My current AWS setup/config makes it difficult for me to run the test suite associated with this repo (I use roles/profiles instead of an access key/secret access key combo). @etianen, could you perhaps run the test suite? I assume you're more accustomed with it than I am :smile