### PR TITLE
Add .copy() and .rename() methods

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -358,6 +358,17 @@ class S3Storage(Storage):
     def delete(self, name):
         self.s3_connection.delete_object(**self._object_params(name))
 
+    @_wrap_errors
+    def copy(self, src_name, dst_name):
+        self.s3_connection.copy_object(
+            CopySource=self._object_params(src_name),
+            **self._object_params(dst_name))
+
+    @_wrap_errors
+    def rename(self, src_name, dst_name):
+        self.copy(src_name, dst_name)
+        self.s3_connection.delete_object(**self._object_params(src_name))
+
     def exists(self, name):
         name = _to_posix_path(name)
         if name.endswith("/"):

--- a/tests/django_s3_storage_test/tests.py
+++ b/tests/django_s3_storage_test/tests.py
@@ -23,6 +23,11 @@ from django_s3_storage.storage import S3Storage, StaticS3Storage
 
 class TestS3Storage(SimpleTestCase):
 
+    def tearDown(self):
+        # clean up the dir
+        for entry in default_storage.listdir(""):
+            default_storage.delete("/".join(entry))
+
     # Helpers.
 
     @contextmanager
@@ -167,6 +172,20 @@ class TestS3Storage(SimpleTestCase):
             self.assertTrue(default_storage.exists("foo.txt"))
             default_storage.delete("foo.txt")
         self.assertFalse(default_storage.exists("foo.txt"))
+
+    def testCopy(self):
+        with self.save_file():
+            self.assertTrue(default_storage.exists("foo.txt"))
+            default_storage.copy("foo.txt", "bar.txt")
+            self.assertTrue(default_storage.exists("foo.txt"))
+        self.assertTrue(default_storage.exists("bar.txt"))
+
+    def testRename(self):
+        with self.save_file():
+            self.assertTrue(default_storage.exists("foo.txt"))
+            default_storage.rename("foo.txt", "bar.txt")
+            self.assertFalse(default_storage.exists("foo.txt"))
+        self.assertTrue(default_storage.exists("bar.txt"))
 
     def testModifiedTime(self):
         with self.save_file():


### PR DESCRIPTION
Hi, I've added these two potentially useful methods. Done this way, the copy operation should be done across S3 servers **without doenloading and uploading again**.

The tests, however, I haven't ran them, as I don't have a testing environment present ATM.