### PR TITLE
Add AWS_S3_USE_THREADS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 django-s3-storage changelog
 ===========================
 
+0.13.6
+------
+- Adding `AWS_S3_USE_THREADS` to fix `gevent` issues (@uxio0).
+
 0.13.5
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,10 @@ Use the following settings to configure the S3 file storage. You must provide at
     # extra characters appended.
     AWS_S3_FILE_OVERWRITE = False
 
+    # If True, use default behaviour for boto3 of using threads when doing S3 operations. If gevent or similar
+    # is used it must be disabled
+    AWS_S3_USE_THREADS = True
+
 **Important:** Several of these settings (noted above) will not affect existing files. To sync the new settings to
 existing files, run ``./manage.py s3_sync_meta django.core.files.storage.default_storage``.
 


### PR DESCRIPTION
When using `gevent`, s3 operations were breaking if using threading. Allow to disable it adding `AWS_S3_USE_THREADS` configuration flag