### PR TITLE
Django 4.1: stop using Django's `utc` alias in favour of directly using `datetime.timezone.utc`

### DIFF
--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -7,6 +7,7 @@ import os
 import posixpath
 import shutil
 from contextlib import closing
+from datetime import timezone
 from functools import wraps
 from io import TextIOBase
 from tempfile import SpooledTemporaryFile
@@ -25,7 +26,7 @@ from django.core.files.storage import Storage
 from django.core.signals import setting_changed
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import filepath_to_uri, force_bytes, force_str
-from django.utils.timezone import make_naive, utc
+from django.utils.timezone import make_naive
 
 log = logging.getLogger(__name__)
 
@@ -449,7 +450,7 @@ class S3Storage(Storage):
         return url
 
     def modified_time(self, name):
-        return make_naive(self.meta(name)["LastModified"], utc)
+        return make_naive(self.meta(name)["LastModified"], timezone.utc)
 
     created_time = accessed_time = modified_time
 


### PR DESCRIPTION
I noticed when starting to test out Django 4.1 that Django is now warning:

```
django_s3_storage/storage.py:28: RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.
```

For reference, prior to Django 4, `django.utils.timezone.utc` was just an alias to `pytz.utc` and from Django 4 onward it is an alias to `datetime.timezone.utc`
- https://github.com/django/django/blob/stable/3.2.x/django/utils/timezone.py#L25
- https://github.com/django/django/blob/stable/4.0.x/django/utils/timezone.py#L44