### PR TITLE
Drop support for deprecated Django versions <3.2 and add support for Django 4.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,32 +13,20 @@ jobs:
       AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
         django-version:
-          - '>=4.0a1,<4.1'
-          - '>=3.2,<4.0'
-          - '>=3.1,<3.2'
-          - '>=3.0,<3.1'
-          - '>=2.2,<3.0'
-          - '>=2.1,<2.2'
-          - '>=2.0,<2.1'
+          - '3.2'
+          - '4.0'
+          - '4.1'
         exclude:
-          - python-version: 3.6
-            django-version: '>=4.0a1,<4.1'
-          - python-version: 3.7
-            django-version: '>=4.0a1,<4.1'
-          - python-version: '3.10'
-            django-version: '>=3.2,<4.0'
-          - python-version: '3.10'
-            django-version: '>=3.1,<3.2'
-          - python-version: '3.10'
-            django-version: '>=3.0,<3.1'
-          - python-version: '3.10'
-            django-version: '>=2.2,<3.0'
-          - python-version: '3.10'
-            django-version: '>=2.1,<2.2'
-          - python-version: '3.10'
-            django-version: '>=2.0,<2.1'
+          - python-version: '3.7'
+            django-version: '4.0'
+          - python-version: '3.7'
+            django-version: '4.1'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -48,7 +36,7 @@ jobs:
     - name: Install dependencies (Django ${{ matrix.django-version }})
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --pre django'${{ matrix.django-version }}'
+        python -m pip install --pre Django~='${{ matrix.django-version }}'
         python -m pip install flake8 coverage requests pytz -e .
     - name: Lint with flake8
       run: |

--- a/django_s3_storage/management/commands/s3_sync_meta.py
+++ b/django_s3_storage/management/commands/s3_sync_meta.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.module_loading import import_string
 
@@ -8,7 +7,7 @@ class Command(BaseCommand):
     help = "Syncronizes the meta information on S3 files."
 
     def add_arguments(self, parser):
-        super(Command, self).add_arguments(parser)
+        super().add_arguments(parser)
         parser.add_argument(
             "storage_path",
             metavar="storage_path",
@@ -20,13 +19,13 @@ class Command(BaseCommand):
         verbosity = int(kwargs.get("verbosity", 1))
         for storage_path in kwargs["storage_path"]:
             if verbosity >= 1:
-                self.stdout.write("Syncing meta for {}".format(storage_path))
+                self.stdout.write(f"Syncing meta for {storage_path}")
             # Import the storage.
             try:
                 storage = import_string(storage_path)
             except ImportError:
-                raise CommandError("Could not import {}".format(storage_path))
+                raise CommandError(f"Could not import {storage_path}")
             # Sync the meta.
             for path in storage.sync_meta_iter():
                 if verbosity >= 1:
-                    self.stdout.write("  Synced meta for {}".format(path))
+                    self.stdout.write(f"  Synced meta for {path}")

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import gzip
 import logging
 import mimetypes
@@ -41,7 +39,7 @@ def _wrap_errors(func):
             err_cls = OSError
             if code == "NoSuchKey":
                 err_cls = FileNotFoundError
-            raise err_cls("S3Storage error at {!r}: {}".format(name, force_str(ex)))
+            raise err_cls(f"S3Storage error at {name!r}: {force_str(ex)}")
     return _do_wrap_errors
 
 
@@ -84,13 +82,13 @@ class S3File(File):
     """
 
     def __init__(self, file, name, storage):
-        super(S3File, self).__init__(file, name)
+        super().__init__(file, name)
         self._storage = storage
 
     def open(self, mode="rb"):
         if self.closed:
             self.file = self._storage.open(self.name, mode).file
-        return super(S3File, self).open(mode)
+        return super().open(mode)
 
 
 class _Local(local):
@@ -209,14 +207,14 @@ class S3Storage(Storage):
                 kwarg_key.upper() not in self.default_auth_settings and
                 kwarg_key.upper() not in self.default_s3_settings
             ):
-                raise ImproperlyConfigured("Unknown S3Storage parameter: {}".format(kwarg_key))
+                raise ImproperlyConfigured(f"Unknown S3Storage parameter: {kwarg_key}")
         # Set up the storage.
         self._kwargs = kwargs
         self._setup()
         # Re-initialize the storage if an AWS setting changes.
         setting_changed.connect(self._setting_changed_received)
         # All done!
-        super(S3Storage, self).__init__()
+        super().__init__()
 
     def __reduce__(self):
         return unpickle_helper, (self.__class__, self._kwargs)
@@ -326,7 +324,7 @@ class S3Storage(Storage):
                     temp_file.seek(0)
                     content = temp_file
                     put_params["ContentEncoding"] = "gzip"
-                    put_params["Metadata"][_UNCOMPRESSED_SIZE_META_KEY] = "{:d}".format(orig_size)
+                    put_params["Metadata"][_UNCOMPRESSED_SIZE_META_KEY] = f"{orig_size:d}"
                 else:
                     content.seek(0)
         # Save the file.
@@ -350,17 +348,17 @@ class S3Storage(Storage):
 
     @_wrap_path_impl
     def get_valid_name(self, name):
-        return super(S3Storage, self).get_valid_name(name)
+        return super().get_valid_name(name)
 
     @_wrap_path_impl
     def get_available_name(self, name, max_length=None):
         if self.settings.AWS_S3_FILE_OVERWRITE:
             return _to_posix_path(name)
-        return super(S3Storage, self).get_available_name(name, max_length=max_length)
+        return super().get_available_name(name, max_length=max_length)
 
     @_wrap_path_impl
     def generate_filename(self, filename):
-        return super(S3Storage, self).generate_filename(filename)
+        return super().generate_filename(filename)
 
     @_wrap_errors
     def meta(self, name):
@@ -537,7 +535,6 @@ class ManifestStaticS3Storage(ManifestFilesMixin, StaticS3Storage):
         initial_aws_s3_max_age_seconds = self.settings.AWS_S3_MAX_AGE_SECONDS
         self.settings.AWS_S3_MAX_AGE_SECONDS = self.settings.AWS_S3_MAX_AGE_SECONDS_CACHED
         try:
-            for r in super(ManifestStaticS3Storage, self).post_process(*args, **kwargs):
-                yield r
+            yield from super().post_process(*args, **kwargs)
         finally:
             self.settings.AWS_S3_MAX_AGE_SECONDS = initial_aws_s3_max_age_seconds

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/etianen/django-s3-storage",
     packages=find_packages(),
     install_requires=[
-        "django>=1.11",
+        "django>=3.2",
         "boto3>=1.4.4,<2",
     ],
     classifiers=[
@@ -26,10 +26,13 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Framework :: Django",
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
     ],
 )

--- a/tests/django_s3_storage_test/tests.py
+++ b/tests/django_s3_storage_test/tests.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import unicode_literals
-
 import posixpath
 import time
 from contextlib import contextmanager
@@ -246,7 +243,7 @@ class TestS3Storage(SimpleTestCase):
                 with self.settings(
                     AWS_S3_BUCKET_AUTH=False,
                     AWS_S3_MAX_AGE_SECONDS=9999,
-                    AWS_S3_CONTENT_DISPOSITION=lambda name: "attachment; filename={}".format(name),
+                    AWS_S3_CONTENT_DISPOSITION=lambda name: f"attachment; filename={name}",
                     AWS_S3_CONTENT_LANGUAGE="eo",
                     AWS_S3_METADATA={
                         "foo": "bar",
@@ -291,7 +288,7 @@ class TestS3Storage(SimpleTestCase):
                 with self.settings(
                     AWS_S3_BUCKET_AUTH=False,
                     AWS_S3_MAX_AGE_SECONDS=9999,
-                    AWS_S3_CONTENT_DISPOSITION=lambda name: "attachment; filename={}".format(name),
+                    AWS_S3_CONTENT_DISPOSITION=lambda name: f"attachment; filename={name}",
                     AWS_S3_CONTENT_LANGUAGE="eo",
                     AWS_S3_METADATA={
                         "foo": "bar",


### PR DESCRIPTION
I was starting to use this with Django 4.1 and noticed `django-s3-storage` was still supporting Python 3.6 and Django 2.2, 3.0 and 4.1 which have [all reached end of life](https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django).

Slightly simplified the GH action matrix by making use of `~=` like `pip install Django~=4.1` to only specify the major/minor version. I can back this change out though and go back to your previous approach if you'd prefer

Also ran `pyupgrade --py37-plus` on codebase (in separate commit)