### PR TITLE
feat: add AWS_S3_CONNECT_TIMEOUT config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 django-s3-storage changelog
 ===========================
 
+0.13.11
+-------
+
+- Added ``AWS_S3_CONNECT_TIMEOUT`` setting (@roriz).
+
 0.13.10
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,12 @@ Use the following settings to configure the S3 file storage. You must provide at
     # is used it must be disabled
     AWS_S3_USE_THREADS = True
 
+    # Max pool of connections for massive S3 interactions
+    AWS_S3_MAX_POOL_CONNECTIONS = 10
+
+    # Time to raise timeout when submitting a new file
+    AWS_S3_CONNECT_TIMEOUT = 60
+
 **Important:** Several of these settings (noted above) will not affect existing files. To sync the new settings to
 existing files, run ``./manage.py s3_sync_meta django.core.files.storage.default_storage``.
 

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -116,7 +116,8 @@ class _Local(local):
         self.s3_connection = self.session.client("s3", config=Config(
             s3={"addressing_style": storage.settings.AWS_S3_ADDRESSING_STYLE},
             signature_version=storage.settings.AWS_S3_SIGNATURE_VERSION,
-            max_pool_connections=storage.settings.AWS_S3_MAX_POOL_CONNECTIONS
+            max_pool_connections=storage.settings.AWS_S3_MAX_POOL_CONNECTIONS,
+            connect_timeout=storage.settings.AWS_S3_CONNECT_TIMEOUT
         ), **connection_kwargs)
 
 
@@ -152,7 +153,8 @@ class S3Storage(Storage):
         "AWS_S3_SIGNATURE_VERSION": "s3v4",
         "AWS_S3_FILE_OVERWRITE": False,
         "AWS_S3_USE_THREADS": True,
-        "AWS_S3_MAX_POOL_CONNECTIONS": 10
+        "AWS_S3_MAX_POOL_CONNECTIONS": 10,
+        "AWS_S3_CONNECT_TIMEOUT": 60 # 60 seconds
     }
 
     s3_settings_suffix = ""


### PR DESCRIPTION
## Description
Create a new config for timeout connection, with this config we can have more control for errors such as `botocore.exceptions.EndpointConnectionError` and fail fast if necessary, or increase the timeout for large files.
