### PR TITLE
feat: permit custom clientMethod for upload file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,22 @@ Please note, however, that **custom URLs will not work with AWS_S3_PUBLIC_URL** 
 URL doesn't accept extra parameters, and it will raise ``ValueError``.
 
 
+Presigned URL
+-----------
+Pre-signed URLs allow temporary access to S3 objects without AWS credentials.
+Generate a URL with permissions and time limit, then provide it to the user for downloading or uploading the object.
+API server does not need to handle the I/O of transferring the file, which can be resource-intensive and slow down the server's response time.
+Instead, the user can directly interact with S3, improving performance and reducing the load on your API server.
+It's secure and flexible for temporary access to S3 objects.
+
+For download a existed file:
+.. code:: python
+    url = storage.url("foo/bar.pdf")
+
+For upload new file: 
+.. code:: python
+    url = storage.url("foo/bar.pdf", clientMethod="put_object")
+
 Management commands
 -------------------
 

--- a/django_s3_storage/storage.py
+++ b/django_s3_storage/storage.py
@@ -436,7 +436,7 @@ class S3Storage(Storage):
         except KeyError:
             return meta["ContentLength"]
 
-    def url(self, name, extra_params=None):
+    def url(self, name, extra_params=None, clientMethod="get_object"):
         # Use a public URL, if specified.
         if self.settings.AWS_S3_PUBLIC_URL:
             if extra_params:
@@ -449,7 +449,7 @@ class S3Storage(Storage):
         params = extra_params.copy() if extra_params else {}
         params.update(self._object_params(name))
         url = self.s3_connection.generate_presigned_url(
-            ClientMethod="get_object",
+            ClientMethod=clientMethod,
             Params=params,
             ExpiresIn=self.settings.AWS_S3_MAX_AGE_SECONDS,
         )


### PR DESCRIPTION
if you're working with AWS S3, you may come across situations where you need to provide temporary access to S3 objects to users or services outside of AWS. In such cases, one of the best solutions is to use pre-signed URLs.

Pre-signed URLs are temporary URLs that grant time-limited access to specific S3 objects. They are signed with AWS credentials, allowing secure access to the objects without the need for the user to have AWS security credentials. To use pre-signed URLs for S3 file downloads or uploads, you'll need to generate the URL with specific parameters that define the permissions and expiration time. For example, if you want to allow a user to download a file from S3, you can generate a pre-signed URL with the "getObject" permission, a specific time limit, and the object key.

Similarly, if you want to allow a user to upload a file to S3, you can generate a pre-signed URL with the "putObject" permission, a specific time limit, and the bucket and object key where the file should be uploaded. Once the pre-signed URL is generated, you can provide it to the client application, who can then use it to perform the allowed operation (download or upload) on the S3 object within the time limit specified.

This means that your API server does not need to handle the I/O of transferring the file, which can be resource-intensive and slow down the server's response time. Instead, the user can directly interact with S3, improving performance and reducing the load on your API server.

More details about S3 signed url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html

## Inspiration
A new version of Ruby on Rails has been recently released, which includes a new feature called "Direct Upload". This feature utilizes pre-signed URLs to enable easier uploading or sharing of backend files, with a full range of capabilities.
More info: https://edgeguides.rubyonrails.org/active_storage_overview.html#direct-uploads